### PR TITLE
fix openapi specs

### DIFF
--- a/skirmserv/api/openapi/game/games_get.yml
+++ b/skirmserv/api/openapi/game/games_get.yml
@@ -9,7 +9,6 @@ responses:
         games:
           type: array
           items:
-            type: object
             properties:
               gid:
                 type: string

--- a/skirmserv/api/openapi/game/get.yml
+++ b/skirmserv/api/openapi/game/get.yml
@@ -31,7 +31,6 @@ responses:
         teams:
           type: array
           items:
-            type: object
             properties:
               tid:
                 type: integer
@@ -46,7 +45,6 @@ responses:
         players:
           type: array
           items:
-            type: object
             properties:
               pid:
                 type: integer

--- a/skirmserv/api/openapi/game/post.yml
+++ b/skirmserv/api/openapi/game/post.yml
@@ -9,7 +9,7 @@ parameters:
     in: path
     required: true
     description: Ignored parameter
-    type: integer
+    type: string
   - name: body
     in: body
     required: true

--- a/skirmserv/api/openapi/game/post.yml
+++ b/skirmserv/api/openapi/game/post.yml
@@ -7,15 +7,13 @@ consumes:
 parameters:
   - name: gid
     in: path
-    required: false
+    required: true
     description: Ignored parameter
-    type: string
+    type: integer
   - name: body
     in: body
     required: true
-    type: object
     schema:
-      type: object
       properties:
         gamemode:
           type: string

--- a/skirmserv/api/openapi/game/put.yml
+++ b/skirmserv/api/openapi/game/put.yml
@@ -11,9 +11,7 @@ parameters:
   - name: body
     in: body
     required: true
-    type: object
     schema:
-      type: object
       properties:
         delay:
           type: integer

--- a/skirmserv/api/openapi/team/post.yml
+++ b/skirmserv/api/openapi/team/post.yml
@@ -18,9 +18,7 @@ parameters:
   - name: body
     in: body
     required: true
-    type: object
     schema:
-      type: object
       properties:
         name:
           type: string
@@ -32,4 +30,17 @@ responses:
   200:
     description: Team was created
     schema:
-      $ref: "#/definitions/Team"
+      id: Team
+      properties:
+        tid:
+          type: integer
+        game:
+          type: string
+        player_count:
+          type: integer
+        points:
+          type: integer
+        rank:
+          type: integer
+        name:
+          type: string

--- a/skirmserv/api/openapi/team/put.yml
+++ b/skirmserv/api/openapi/team/put.yml
@@ -18,9 +18,7 @@ parameters:
   - name: body
     in: body
     required: true
-    type: object
     schema:
-      type: object
       properties:
         pid:
           type: integer

--- a/skirmserv/api/openapi/user/auth_post.yml
+++ b/skirmserv/api/openapi/user/auth_post.yml
@@ -5,10 +5,8 @@ consumes:
 parameters:
   - name: body
     in: body
-    type: object
     required: true
     schema:
-      type: object
       properties:
         email:
           type: string

--- a/skirmserv/api/openapi/user/post.yml
+++ b/skirmserv/api/openapi/user/post.yml
@@ -1,21 +1,23 @@
 tags:
   - user
 parameters:
-  - name: name
-    in: body
+  - name: UserInfo
     required: true
-    description: Username
-    type: string
-  - name: email
+    description: information for the new user
     in: body
-    required: true
-    description: E-Mail address
-    type: string
-  - name: password
-    in: body
-    required: true
-    description: Password
-    type: string
+    schema:
+      type: object
+      required:
+        - name
+        - email
+        - password
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+        password:
+          type: string
 responses:
   409:
     description: The E-Mail address is already in use.


### PR DESCRIPTION
See https://github.com/skrmsh/app/issues/47 

Adjust the yamls so that a valid spec is generated.
Spec has been validated by [Swagger online validator](https://apitools.dev/swagger-parser/online/) and [openapi-spec-validator](https://github.com/python-openapi/openapi-spec-validator), both reported no issues. 
In the future, it might be worth to look into adding a github action which validates the spec automatically, however maybe in a different issue.